### PR TITLE
Add RegExp flag support similar to JSv4 "patternFlags"

### DIFF
--- a/index.js
+++ b/index.js
@@ -122,11 +122,11 @@ var compile = function(schema, cache, root, reporter, opts) {
   }
 
   var reversePatterns = {}
-  var patterns = function(p) {
-    if (reversePatterns[p]) return reversePatterns[p]
+  var patterns = function(p, flags = '') {
+    if (reversePatterns[p+flags]) return reversePatterns[p+flags]
     var n = gensym('pattern')
-    scope[n] = new RegExp(p)
-    reversePatterns[p] = n
+    scope[n] = new RegExp(p, flags)
+    reversePatterns[p+flags] = n
     return n
   }
 
@@ -389,7 +389,7 @@ var compile = function(schema, cache, root, reporter, opts) {
     }
 
     if (node.pattern) {
-      var p = patterns(node.pattern)
+      var p = patterns(node.pattern, node.patternFlags || '')
       if (type !== 'string') validate('if (%s) {', types.string(name))
       validate('if (!(%s.test(%s))) {', p, name)
       error('pattern mismatch')

--- a/index.js
+++ b/index.js
@@ -389,7 +389,7 @@ var compile = function(schema, cache, root, reporter, opts) {
     }
 
     if (node.pattern) {
-      var p = patterns(node.pattern, node.patternFlags || '')
+      var p = patterns(node.pattern, (typeof node.patternFlags === 'string') ? node.patternFlags : '')
       if (type !== 'string') validate('if (%s) {', types.string(name))
       validate('if (!(%s.test(%s))) {', p, name)
       error('pattern mismatch')

--- a/test/misc.js
+++ b/test/misc.js
@@ -488,3 +488,18 @@ tape('patternFlags', function(t) {
   t.notOk(validate({anyFoo:"bar"}))
   t.end()
 })
+
+tape('invalid patternFlags', function(t) {
+  [ null, "1", {}, [], 1, "iii" ].map(
+    function (invalidFlags) {
+      var validate = validator({
+        type: 'string',
+        pattern: "foo",
+        patternFlags: invalidFlags,
+      })
+      t.notOk(validate("Foo"), "Should not match with invalid patternFlags: " + JSON.stringify(invalidFlags))
+      t.ok(validate("foo"), "Should ignore invalid patternFlags: " + JSON.stringify(invalidFlags))
+    }
+  )
+  t.end()
+})

--- a/test/misc.js
+++ b/test/misc.js
@@ -469,3 +469,22 @@ tape('field shows item index in arrays', function(t) {
   t.strictEqual(validate.errors[0].field, 'data.1.1.foo', 'should output the field with specific index of failing item in the error')
   t.end()
 })
+
+tape('patternFlags', function(t) {
+  var validate = validator({
+    type: 'object',
+    properties: {
+      anyFoo: {
+        type: 'string',
+        pattern: "foo",
+        patternFlags: "i",
+      }
+    }
+  })
+
+  t.ok(validate({anyFoo:"foo"}))
+  t.ok(validate({anyFoo:"FOO"}))
+  t.ok(validate({anyFoo:"Foo"}))
+  t.notOk(validate({anyFoo:"bar"}))
+  t.end()
+})


### PR DESCRIPTION
It can be ridiculously inconvenient that JSON Schema doesn't support RegExp flags, so let's add them?

```
node -p 'var validator = require("./index.js");
var validate = validator( {"pattern":"foo"} );
var iValidate = validator( {"pattern":"foo", "patternFlags":"i"} );
[
  validate("foo"),  // true
  validate("FOO"),  // false
  iValidate("foo"), // true
  iValidate("FOO"), // true
];'
```

`patternFlags` is a non-standard extension that I've picked because Jsv4 supports it, so we'd have similar functionality front and back: https://github.com/geraintluff/jsv4-php/blob/master/src/Jsv4/Validator.php#L431 

There's no equivalent in more recent JSON Schema, so no compatibility worries there. (I do wonder why this hasn't been addressed).

The code change itself should have nearly no impact on performance. We already create the `RegExp` object at compile time and pass it to the generated validation function, so we just check for a `patternFlags` property and pass it to the RegExp constructor once at compile time.

I don't know if I should add the option for patternProperties - personally I don't see the value proposition, but I've seen a few people ask for it.

To merge upstream, we'd need to put this behind an option and default it off. I don't see any issues related to it, so I don't know if the PR would be accepted.
